### PR TITLE
Sik 2356 language code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smartconnect-client"
-version = "1.4.3"
+version = "1.4.4"
 description = ""
 authors = ["Chris Doehring <chrisdo@earthranger.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smartconnect-client"
-version = "1.4.4"
+version = "1.4.5"
 description = ""
 authors = ["Chris Doehring <chrisdo@earthranger.com>"]
 

--- a/smartconnect/__init__.py
+++ b/smartconnect/__init__.py
@@ -298,7 +298,7 @@ class SmartClient:
                            status_code=ca_datamodel.status_code))
             raise Exception('Failed to download Data Model')
 
-        dm = DataModel()
+        dm = DataModel(use_language_code=self.use_language_code)
         dm.load(ca_datamodel.text)
         return dm
 

--- a/smartconnect/__init__.py
+++ b/smartconnect/__init__.py
@@ -190,7 +190,7 @@ class SmartClient:
                            status_code=config_datamodel.status_code))
             raise Exception('Failed to download Data Model')
 
-        cdm = ConfigurableDataModel(cm_uuid=cm_uuid)
+        cdm = ConfigurableDataModel(cm_uuid=cm_uuid, use_language_code=self.use_language_code)
         cdm.load(config_datamodel.text)
         
         return cdm
@@ -242,7 +242,7 @@ class SmartClient:
             try:
                 cached_data = cache.cache.get(cache_key)
                 if cached_data:
-                    dm = DataModel()
+                    dm = DataModel(use_language_code=self.use_language_code)
                     dm.import_from_dict(json.loads(cached_data))
                     self.logger.debug(
                         f"Using cached SMART Datamodel", extra={"cached_key": cache_key}


### PR DESCRIPTION
This is a bugfix to resolve an issue where a user's chosen language code was not being used for translate a Smart data model to EarthRanger Event Types.

[SIK-2356](https://allenai.atlassian.net/browse/SIK-2356)

[SIK-2356]: https://allenai.atlassian.net/browse/SIK-2356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ