### PR TITLE
Use JessionId auth in synchronous client.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smartconnect-client"
-version = "1.5.3"
+version = "1.6.0"
 description = ""
 authors = ["Chris Doehring <chrisdo@earthranger.com>"]
 
@@ -29,6 +29,7 @@ pytest = "^7.2"
 pytest-asyncio = "^0.20"
 pytest-mock = "^3.14.0"
 respx = "^0.20.2"
+requests-mock = "^1.12.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_async_session.py
+++ b/tests/test_async_session.py
@@ -1,0 +1,49 @@
+import pytest
+import respx
+import httpx
+from smartconnect import AsyncSmartClient, SMARTClientException
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_client_login():
+    # Mock the login response
+    respx.post(
+        "https://fancyplace.smartconservationtools.org/server/j_security_check"
+    ).respond(status_code=200)
+
+    respx.get(
+        "https://fancyplace.smartconservationtools.org/server/connect/home").respond(status_code=200)
+
+    smart_client = AsyncSmartClient(
+        api="https://fancyplace.smartconservationtools.org/server",
+        username="Earthranger",
+        password="afancypassword"
+    )
+
+    # Perform the login
+    session = await smart_client.ensure_login()
+
+    # Check if login was successful
+    assert session is not None
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_client_login_negative():
+    # Mock the login response
+    respx.post(
+        "https://fancyplace.smartconservationtools.org/server/j_security_check"
+    ).respond(status_code=401)
+
+    respx.get(
+        "https://fancyplace.smartconservationtools.org/server/connect/home").respond(status_code=200)
+
+    smart_client = AsyncSmartClient(
+        api="https://fancyplace.smartconservationtools.org/server",
+        username="Earthranger",
+        password="afancypassword"
+    )
+
+    
+    with pytest.raises(SMARTClientException):
+        # Perform the login
+        await smart_client.ensure_login()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,43 +1,35 @@
 import pytest
-import respx
-import httpx
-from smartconnect import AsyncSmartClient, SMARTClientException
+import requests, requests_mock
+from smartconnect import SmartClient, SMARTClientException
 
-@pytest.mark.asyncio
-@respx.mock
-async def test_async_client_login():
+def test_async_client_login(requests_mock):
     # Mock the login response
-    respx.post(
-        "https://fancyplace.smartconservationtools.org/server/j_security_check"
-    ).respond(status_code=200)
+    requests_mock.post("https://fancyplace.smartconservationtools.org/server/j_security_check", status_code=200)
 
-    respx.get(
-        "https://fancyplace.smartconservationtools.org/server/connect/home").respond(status_code=200)
+    requests_mock.get(
+        "https://fancyplace.smartconservationtools.org/server/connect/home", status_code=200)
 
-    smart_client = AsyncSmartClient(
+    smart_client = SmartClient(
         api="https://fancyplace.smartconservationtools.org/server",
         username="Earthranger",
         password="afancypassword"
     )
 
     # Perform the login
-    session = await smart_client.ensure_login()
+    session = smart_client.ensure_login()
 
     # Check if login was successful
     assert session is not None
 
-@pytest.mark.asyncio
-@respx.mock
-async def test_async_client_login_negative():
+def test_client_login_negative(requests_mock):
     # Mock the login response
-    respx.post(
-        "https://fancyplace.smartconservationtools.org/server/j_security_check"
-    ).respond(status_code=401)
+    requests_mock.post(
+        "https://fancyplace.smartconservationtools.org/server/j_security_check", status_code=401)
 
-    respx.get(
-        "https://fancyplace.smartconservationtools.org/server/connect/home").respond(status_code=200)
+    requests_mock.get(
+        "https://fancyplace.smartconservationtools.org/server/connect/home", status_code=200)
 
-    smart_client = AsyncSmartClient(
+    smart_client = SmartClient(
         api="https://fancyplace.smartconservationtools.org/server",
         username="Earthranger",
         password="afancypassword"
@@ -46,4 +38,4 @@ async def test_async_client_login_negative():
     
     with pytest.raises(SMARTClientException):
         # Perform the login
-        await smart_client.ensure_login()
+        smart_client.ensure_login()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,7 +2,7 @@ import pytest
 import requests, requests_mock
 from smartconnect import SmartClient, SMARTClientException
 
-def test_async_client_login(requests_mock):
+def test_client_login(requests_mock):
     # Mock the login response
     requests_mock.post("https://fancyplace.smartconservationtools.org/server/j_security_check", status_code=200)
 


### PR DESCRIPTION
Eliminates use of basic auth against smartconnect servers.

This covers the synchronous client used in Gundi's portal to interact with Smart Connect.
TIcket: [GUNDI-3195](https://allenai.atlassian.net/browse/GUNDI-3195)

[GUNDI-3195]: https://allenai.atlassian.net/browse/GUNDI-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ